### PR TITLE
PHP 7.0 for WordPress compatibility

### DIFF
--- a/OptionsResolver.php
+++ b/OptionsResolver.php
@@ -977,7 +977,7 @@ class OptionsResolver implements Options
      *
      * @param mixed $value The value to return the type of
      */
-    private function formatTypeOf($value, ?string $type): string
+    private function formatTypeOf($value, $type): string
     {
         $suffix = '';
 


### PR DESCRIPTION
The WP plugins directory software do not accept commits if the PHP code features used are above the 7.0 version.